### PR TITLE
Remove the "useless badge"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # mpv-libunity
-`mpv-libunity` is a mpv plugin that shows a nice progress bar (and a useless badge) on your panel/dock using libunity specification. Obviously this only works on linux and with panels that support libunity (such as kde plasma or dash-to-dock on gnome). Cinnamon panel is also supported via `cinnamon.lua` (but you will need xdotool and xprop in that case).
+`mpv-libunity` is a mpv plugin that shows a nice progress bar on your panel/dock using libunity specification. Obviously this only works on linux and with panels that support libunity (such as kde plasma or dash-to-dock on gnome). Cinnamon panel is also supported via `cinnamon.lua` (but you will need xdotool and xprop in that case).
 
 ![](image.png)
 

--- a/libunity.c
+++ b/libunity.c
@@ -15,8 +15,6 @@ void set_progress(double pos, double len)
     signal << "application://mpv.desktop";
     QVariantMap setProperty;
 
-    setProperty.insert("count", qint64(1));
-    setProperty.insert("count-visible", true);
     setProperty.insert("progress", double(pos / len));
     setProperty.insert("progress-visible", true);
 


### PR DESCRIPTION
The counter is not used by mpv in any meaningful way, as it always shows 1. This patch removes it completely, avoiding ambiguities. If merged, a new image.png should be created.